### PR TITLE
Filter repositories with no name at Data providers page

### DIFF
--- a/components/repositories-browser/index.jsx
+++ b/components/repositories-browser/index.jsx
@@ -34,7 +34,7 @@ class RepositoryBrowser extends Component {
   async componentDidMount() {
     const { endpoint } = this.props
     const repositories = await RepositoryBrowser.fetchRepositories(endpoint)
-    repositories.sort((a, b) => a.name.localeCompare(b.name))
+    repositories.sort((a, b) => (a.name || '').localeCompare(b.name || ''))
     this.repositories = new Fuse(repositories, RepositoryBrowser.searchOptions)
     this.setState({
       items: this.repositories.list.slice(),

--- a/components/repositories-browser/index.jsx
+++ b/components/repositories-browser/index.jsx
@@ -109,7 +109,7 @@ class RepositoryBrowser extends Component {
               <Card body className="data-providers-card">
                 <CardTitle>
                   <Link href={`~search?q=repositories.id:${item.id}`}>
-                    {item.name || 'Unnamed repository'}
+                    {item.name || 'No name repository'}
                   </Link>
                 </CardTitle>
 

--- a/components/repositories-browser/index.jsx
+++ b/components/repositories-browser/index.jsx
@@ -18,10 +18,14 @@ class RepositoryBrowser extends Component {
   static pageSize = 10
 
   static fetchRepositories(url) {
-    return fetch(url).then(res => {
-      if (res.ok) return res.json()
-      throw new Error(`Error loading repositories from ${url}`)
-    })
+    return fetch(url)
+      .then(res => {
+        if (res.ok) return res.json()
+        throw new Error(`Error loading repositories from ${url}`)
+      })
+      .then(repositories =>
+        repositories.filter(({ name }) => name && name !== 'name')
+      )
   }
 
   state = {


### PR DESCRIPTION
Hot fix to prevent infinite loading of repositories on [Data providers page](https://core.ac.uk/data/providers).

Changes:
- improved sort comparator to avoid comparing `null`s
- filtered repositories with no name (`name: null`)