### PR TITLE
Improved  Discovery plugin instructions for EPrints

### DIFF
--- a/data/documentation/discovery-plugin.md
+++ b/data/documentation/discovery-plugin.md
@@ -25,11 +25,14 @@ CORE Repository Dashboard you can move on with the instructions below.
 </p>
 
 You can install the&nbsp;plugin by copying and pasting the following snippet.
+Please note that due to the way that the EPrints template engine works,
+the script URL contains escaped HTML entities.
 
 ```html
-<script 
-  src="https://discovery.core.ac.uk/plugin.js?template=eprints&id=XXXXX" 
-  async
+<script
+  type="text/javascript"
+  src="https://discovery.core.ac.uk/plugin.js?template=eprints&amp;id=XXXXX" 
+  async="async"
 ></script>
 ```
 


### PR DESCRIPTION
@mcancellieri, @nancypontika can we say it better?

Based on the email:

> The issue is that, essentially, the template for the page where the script line is added is an XML file and is parsed as such before the html page is generated.  As such it treats ampersand as a special character delimiter so it needs the full &amp; to parse.  It also needs the async attribute to be defined with a value (i.e. `async="async"`) otherwise it doesn’t validate as XML.
>
> The line I’m using now is therefore:
>
> ```html
> <script async="async" type="text/javascript" src="https://discovery.core.ac.uk/plugin.js?id=XXXX&amp;template=eprints"></script>
> ```
>
> It would be useful to update the documentation (for the eprints specific part) to reflect those points.