### PR TITLE
Specify engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "Knowledge Media Institute",
   "license": "MIT",
   "private": true,
+  "engines": {
+    "node": ">=12"
+  },
   "devDependencies": {
     "@babel/core": "7.7.4",
     "@babel/plugin-proposal-class-properties": "^7.7.4",


### PR DESCRIPTION
Now deployment doesn't work because of no longer supported  node version (8.x)