### PR TITLE
Enable data provider registration

### DIFF
--- a/core.routes.yml
+++ b/core.routes.yml
@@ -62,6 +62,9 @@ services-dataset-dynamic-render:
 
 data: /data
 data-providers: /data/providers
+# Despite this might look as a mistake, the route is hosted from oacore/search
+# with a reverse proxy configured to the current website.
+register-data-provider: /data-providers
 
 repositories:
   pattern:  /repositories

--- a/data/faq.yml
+++ b/data/faq.yml
@@ -22,7 +22,7 @@ sections:
           If your repository or journal is already registered with
           some authoritative registry, you don't need to do anything.
           If your repository or journal has not been registered
-          yet get in [touch](~contact).
+          yet use [the form](~register-data-provider) to add it.
       - slug: where-are-the-repositories-harvested-by-CORE-located
         question: Where are the repositories harvested by CORE located?
         answer: |

--- a/pages/about/index.jsx
+++ b/pages/about/index.jsx
@@ -102,7 +102,7 @@ const AboutPage = () => (
         </Row>
 
         <ButtonToolbar align="center" className="flex-row-reverse">
-          <Button color="primary" outline href="~contact">
+          <Button color="primary" outline href="~register-data-provider">
             {aboutData.howItWorks.harvesting.actions.primary}
           </Button>
 

--- a/pages/data/providers.jsx
+++ b/pages/data/providers.jsx
@@ -27,7 +27,7 @@ const DataProvidersPage = () => (
         {patchStats(repositoriesData.content, repositoriesData.statistics)}
       </Markdown>
 
-      <Button color="primary" href="~contact">
+      <Button color="primary" href="~register-data-provider">
         {repositoriesData.become}
       </Button>
     </Content>


### PR DESCRIPTION
Replaces all the button links from contacts section to `/data-providers` from [oacore/search](/oacore/search).