### PR TITLE
Remove Bootstrap Container from Section

### DIFF
--- a/components/content/article.jsx
+++ b/components/content/article.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import {
-  Container as BootstrapContainer,
-  Nav,
-  NavItem,
-  NavLink,
-} from 'reactstrap'
+import { Nav, NavItem, NavLink } from 'reactstrap'
+
+const ArticleHeader = ({ children, className, ...restProps }) => (
+  <div className={`article-header container ${className || ''}`} {...restProps}>
+    {children}
+  </div>
+)
 
 const ArticleNav = ({ items }) => (
   <Nav className="article-nav">
@@ -50,14 +51,14 @@ const Article = ({ children, ...props }) => {
     if (header.length === 0) return null
 
     return (
-      <BootstrapContainer>
+      <ArticleHeader>
         {header}
         {nav && <ArticleNav items={navItems} />}
-      </BootstrapContainer>
+      </ArticleHeader>
     )
   }
 
-  const { nav, className, tag: Tag, ...restProps } = props
+  const { nav, className, tag: Tag = 'acticle', ...restProps } = props
 
   return (
     <Tag className={`article ${className || ''}`.trim()} {...restProps}>

--- a/components/content/content.scss
+++ b/components/content/content.scss
@@ -68,10 +68,27 @@ $article-spacer: $section-lg-spacer !default;
 
 .section {
   position: relative;
+  display: grid;
   padding-top: $section-spacer;
   padding-bottom: $section-spacer;
+  // Fake padding for extra-small screens
+  grid-template-columns: ($grid-gutter-width / 2) 1fr ($grid-gutter-width / 2);
 
-  > .container > .section {
+  @each $breakpoint, $container-max-width in $container-max-widths {
+    @include media-breakpoint-up($breakpoint, $grid-breakpoints) {
+      grid-template-columns: 1fr ($container-max-width - $grid-gutter-width) 1fr;
+    }
+  }
+
+  > * {
+    grid-column: 2;
+  }
+
+  & > .section {
+    grid-column: 1 / -1;
+  }
+
+  > .section {
     padding-top: $section-sm-spacer;
     padding-bottom: $section-sm-spacer;
 
@@ -109,14 +126,6 @@ $article-spacer: $section-lg-spacer !default;
   & > .section:last-child {
     padding-bottom: $article-spacer;
     margin-bottom: -$article-spacer;
-  }
-}
-
-.article,
-.section {
-  > .container .container {
-    padding-left: 0;
-    padding-right: 0;
   }
 }
 

--- a/components/content/section.jsx
+++ b/components/content/section.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Container as BootstrapContainer } from 'reactstrap'
 
 const Section = props => {
   const {
@@ -7,7 +6,6 @@ const Section = props => {
     large = false,
     small = false,
     className = '',
-    container = true,
     tag: Tag = 'section',
     ...restProps
   } = props
@@ -20,17 +18,9 @@ const Section = props => {
     .filter(truthy => truthy)
     .join(' ')
 
-  if (!container) {
-    return (
-      <Tag className={classNames} {...restProps}>
-        {children}
-      </Tag>
-    )
-  }
-
   return (
     <Tag className={classNames} {...restProps}>
-      <BootstrapContainer>{children}</BootstrapContainer>
+      {children}
     </Tag>
   )
 }

--- a/components/hero/hero.scss
+++ b/components/hero/hero.scss
@@ -1,4 +1,4 @@
-@import "../bootstrap/core";
+@import '../bootstrap/core';
 
 .hero {
   padding-top: $article-spacer;

--- a/components/pages/service.scss
+++ b/components/pages/service.scss
@@ -1,4 +1,4 @@
-@import "../components/bootstrap/core";
+@import '../components/bootstrap/core';
 
 .service-section {
 }
@@ -7,7 +7,7 @@
   align-items: center;
   text-align: center;
 
-  @include media-breakpoint-up("sm") {
+  @include media-breakpoint-up('sm') {
     text-align: left;
   }
 }
@@ -19,7 +19,7 @@
     height: auto;
   }
 
-  @include media-breakpoint-up("sm") {
+  @include media-breakpoint-up('sm') {
     text-align: right;
 
     .service-section:nth-child(odd) & {
@@ -45,7 +45,7 @@
   text-align: center;
   margin: map-get($spacers, 1) / -2;
 
-  @include media-breakpoint-up("sm") {
+  @include media-breakpoint-up('sm') {
     text-align: left;
   }
 
@@ -63,14 +63,14 @@
 .service-page-title {
   text-align: center;
 
-  @include media-breakpoint-up("md") {
+  @include media-breakpoint-up('md') {
     text-align: left;
   }
 
   + .article-nav {
     justify-content: center;
 
-    @include media-breakpoint-up("md") {
+    @include media-breakpoint-up('md') {
       justify-content: flex-start;
     }
   }
@@ -87,6 +87,7 @@
 }
 
 .service-page-screenshot {
+  width: 100%;
   max-width: $content-max-width;
   margin-right: auto;
   margin-left: auto;

--- a/components/sections/join.jsx
+++ b/components/sections/join.jsx
@@ -16,9 +16,11 @@ const JoinSection = ({
   <Section id={id} className={`join-section ${className}`} {...restProps}>
     <h2>{title}</h2>
     <Markdown className="join-section-lead">{lead}</Markdown>
-    <Button className="join-core-button" size="lg" href="~services">
-      {action}
-    </Button>
+    <p className="join-section-button-container">
+      <Button className="join-core-button" size="lg" href="~services">
+        {action}
+      </Button>
+    </p>
     <footer className="join-section-note">
       <Markdown>{note}</Markdown>
     </footer>

--- a/components/sections/join.scss
+++ b/components/sections/join.scss
@@ -1,7 +1,7 @@
-@import "../bootstrap/core";
+@import '../bootstrap/core';
 
 .join-section {
-  background: $nearly-black url("../images/blue-lights-bg.jpg") no-repeat center /
+  background: $nearly-black url('../images/blue-lights-bg.jpg') no-repeat center /
     cover;
   color: $light;
   text-align: center;
@@ -31,6 +31,10 @@
       color: $link-hover-color;
     }
   }
+}
+
+.join-section-button-container {
+  margin-bottom: 0;
 }
 
 .join-core-button {

--- a/pages/about/about.module.scss
+++ b/pages/about/about.module.scss
@@ -4,6 +4,10 @@ $skew-section-icon-size: 4rem;
 
 .about-services-section {
   @include section-skew-left($blue-light);
+
+  > p:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .about-endorsements-section {
@@ -17,12 +21,17 @@ $skew-section-icon-size: 4rem;
     position: relative;
     top: -1 * $spacer;
     display: block;
+    grid-column: 2;
     width: 2 * $icon-size + $spacer;
     height: $icon-size;
-    margin: auto;
+    margin: 0 auto;
     background: url('/images/icons/university.svg') no-repeat 0 50%,
       url('/images/icons/factory.svg') no-repeat 100% 50%;
     background-size: auto 100%;
+  }
+
+  > p:last-child {
+    margin-bottom: 0;
   }
 }
 
@@ -40,12 +49,17 @@ $skew-section-icon-size: 4rem;
     content: '';
     position: relative;
     top: -1 * $spacer;
+    grid-column: 2;
     display: block;
     width: $icon-size;
     height: $icon-size;
-    margin: auto;
+    margin: 0 auto;
     /* Icon made by Freepik (https://www.flaticon.com/authors/freepik) */
     background: url('/images/icons/group.svg') no-repeat center / contain;
+  }
+
+  > p:last-child {
+    margin-bottom: 0;
   }
 }
 

--- a/pages/about/index.jsx
+++ b/pages/about/index.jsx
@@ -77,9 +77,11 @@ const AboutPage = () => (
         {aboutData.endorsements.title}
       </h2>
       <Markdown>{aboutData.endorsements.content}</Markdown>
-      <Button color="primary" outline href="~about/endorsements">
-        {aboutData.endorsements.action}
-      </Button>
+      <p>
+        <Button color="primary" outline href="~about/endorsements">
+          {aboutData.endorsements.action}
+        </Button>
+      </p>
     </Section>
 
     <Section id="how-it-works" caption="How it works">
@@ -121,9 +123,11 @@ const AboutPage = () => (
 
       <ServiceGroups items={servicesData.sections} className="text-left" />
 
-      <Button color="primary" outline href="~services">
-        {aboutData.howItWorks.services.actions.secondary}
-      </Button>
+      <p>
+        <Button color="primary" outline href="~services">
+          {aboutData.howItWorks.services.actions.secondary}
+        </Button>
+      </p>
     </Section>
 
     <Section id="team" caption={teamData.shortTitle}>
@@ -166,9 +170,11 @@ const AboutPage = () => (
     >
       <h2>{aboutData.ambassadors.title}</h2>
       <Markdown>{aboutData.ambassadors.body}</Markdown>
-      <Button color="primary" outline href="~about/ambassadors">
-        {aboutData.ambassadors.action}
-      </Button>
+      <p>
+        <Button color="primary" outline href="~about/ambassadors">
+          {aboutData.ambassadors.action}
+        </Button>
+      </p>
     </Section>
 
     <Section id="resources" caption={aboutData.resources.shortTitle}>

--- a/pages/data/providers.jsx
+++ b/pages/data/providers.jsx
@@ -22,8 +22,8 @@ const DataProvidersPage = () => (
     nav
   >
     <h1 className="page-title">{repositoriesData.title}</h1>
-    <div className="container">
-      <Content className="content">
+    <Section tag="div">
+      <Content>
         <Markdown>
           {patchStats(repositoriesData.content, repositoriesData.statistics)}
         </Markdown>
@@ -32,7 +32,7 @@ const DataProvidersPage = () => (
           {repositoriesData.become}
         </Button>
       </Content>
-    </div>
+    </Section>
 
     <Section id="map" caption={repositoriesData.map}>
       <h2>{repositoriesData.map}</h2>

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -81,7 +81,7 @@ const IndexPage = () => (
     keywords={page.keywords}
   >
     <Hero headline={page.hero.headline} tagline={page.hero.tagline}>
-      <Section tag="div">
+      <div className="py-section-sm">
         <SearchForm
           action="/search"
           name="q"
@@ -90,7 +90,7 @@ const IndexPage = () => (
         <SearchIntro>
           <Markdown>{page.covid19Notice}</Markdown>
         </SearchIntro>
-      </Section>
+      </div>
     </Hero>
 
     <Section className="pb-section-lg">

--- a/pages/index.module.scss
+++ b/pages/index.module.scss
@@ -13,24 +13,9 @@
 }
 
 .home-endorsements-section {
-  overflow: hidden;
   background: $beige;
 }
 
 .home-academic-institutions-section {
-  position: relative;
-
-  & > * {
-    position: relative;
-  }
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: -2000px;
-    width: 1000%;
-    height: 100%;
-    background: $beige-dark;
-  }
+  background: $beige-dark;
 }


### PR DESCRIPTION
Replaces the container with the CSS grid. Thanks to [Per Harald Borgen](https://www.freecodecamp.org/news/how-to-recreate-mediums-article-layout-with-css-grid-b4608792bad1/).

Some things break but I like it a lot!

@Joozty it would be very kind if you could pass me the list of workarounds we have. If you don't have time, I can find it from the history 🙂