### PR TITLE
Change search bar label

### DIFF
--- a/main/index.jsx
+++ b/main/index.jsx
@@ -37,7 +37,7 @@ const Main = ({ children }) => {
       },
       initQuery: '',
       searchBarProps: {
-        label: 'Search',
+        label: searchConfig.placeholder,
         placeholder: searchConfig.placeholder,
         prependIcon: '#magnify',
         changeOnBlur: false,


### PR DESCRIPTION
`Search` is too short and doesn't look good to me. Not sure if it was there before the migration or I unintentionally changed it.